### PR TITLE
feat: .sort() method for list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ slash-fuzz
 
 .idea/*
 idea
+
+# ignore vscode settings
+.vscode/*
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "files.associations": {
+        "*.h": "c",
+        "array": "c",
+        "string": "c",
+        "string_view": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "files.associations": {
-        "*.h": "c",
-        "array": "c",
-        "string": "c",
-        "string_view": "c"
-    }
-}

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ DIRS := $(shell find $(SRC) -type d)
 SRCS := $(shell find $(SRC) -type f -name "*.c")
 OBJS := $(SRCS:%.c=$(OBJDIR)/%.o)
 
-CFLAGS = -Iinclude -Wall -Wpedantic -Wextra -Wshadow -std=c11
+CFLAGS = -Iinclude -Wall -Wpedantic -Wextra -Wshadow -std=gnu11
 CFLAGS += -DNDEBUG
 LDFLAGS = -lm
 
@@ -23,13 +23,13 @@ $(OBJDIR)/%.o: %.c Makefile | $(OBJDIR)
 
 $(TARGET): $(OBJS)
 	@echo [LD] $@
-	@$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+	@$(CC) -o $@ $^ $(LDFLAGS) $(LDLIBS)
 
 $(TARGET-FUZZ): $(OBJS)
 	@echo [LD] $@
 	@$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
-debug: CFLAGS = -Iinclude -Wall -Wpedantic -Wextra -Wshadow -std=c11 -g -DDEBUG -DDEBUG_PERF
+debug: CFLAGS = -Iinclude -Wall -Wpedantic -Wextra -Wshadow -std=gnu11 -g -DDEBUG -DDEBUG_PERF
 debug: $(TARGET)
 
 fuzz: CFLAGS += -fsanitize=address -fsanitize=undefined

--- a/examples/shellsort.slash
+++ b/examples/shellsort.slash
@@ -1,0 +1,29 @@
+# Init array
+var numbers = [9, 8, 3, 7, 5, 6, 4, 1, 9, 8, 3, 7, 5, 6, 4, 1, 9, 8, 3, 7, 5, 6, 4, 1, 9, 8, 3, 7, 5]
+
+# Calculate interval
+var interval = ($numbers.len() - 1) // 2
+
+# Shell sort
+loop $interval > 0 {
+    var i = $interval
+    loop $i < $numbers.len() {
+        var temp = $numbers[$i]
+        echo "Temp: " $temp
+        var j = $i
+        loop $j >= $interval and $numbers[$j - $interval] > $temp{
+            $numbers[$j] = $numbers[$j - $interval]
+            $j = $j - $interval
+        }
+
+        $numbers[$j] = $temp
+        $i = $i + 1
+    }
+
+    $interval = $interval // 2
+}
+
+# Print sorted array
+loop number in $numbers {
+    $number
+}

--- a/include/interpreter/lexer.h
+++ b/include/interpreter/lexer.h
@@ -38,7 +38,7 @@
 #define KEYWORD_TOKENS \
     X(var)             \
     X(func)            \
-    X(return)          \
+    X(return )         \
     X(if)              \
     X(elif)            \
     X(else)            \

--- a/include/interpreter/types/slash_bool.h
+++ b/include/interpreter/types/slash_bool.h
@@ -22,5 +22,6 @@ typedef struct slash_value_t SlashValue; // Forward declaration of SlashValue
 
 void slash_bool_print(SlashValue *value);
 
+int slash_bool_cmp(const void *a, const void *b);
 
 #endif /* SLASH_BOOL_H */

--- a/include/interpreter/types/slash_list.h
+++ b/include/interpreter/types/slash_list.h
@@ -59,11 +59,12 @@ void slash_list_item_assign(SlashValue *self, SlashValue *index, SlashValue *new
 bool slash_list_item_in(SlashValue *self, SlashValue *item);
 
 /* slash list methods */
-#define SLASH_LIST_METHODS_COUNT 2
+#define SLASH_LIST_METHODS_COUNT 3
 extern SlashMethod slash_list_methods[SLASH_LIST_METHODS_COUNT];
 
 SlashValue slash_list_pop(SlashValue *self, size_t argc, SlashValue *argv);
 SlashValue slash_list_len(SlashValue *self, size_t argc, SlashValue *argv);
+SlashValue slash_list_sort(SlashValue *self, size_t argc, SlashValue *argv);
 
 
 #endif /* SLASH_LIST_H */

--- a/include/interpreter/types/slash_num.h
+++ b/include/interpreter/types/slash_num.h
@@ -21,4 +21,6 @@ typedef struct slash_value_t SlashValue; // Forward declaration of SlashValue
 
 void slash_num_print(SlashValue *value);
 
+int slash_num_cmp(const void *a, const void *b);
+
 #endif /* SLASH_NUM_H */

--- a/include/interpreter/types/slash_str.h
+++ b/include/interpreter/types/slash_str.h
@@ -24,5 +24,6 @@ typedef struct slash_value_t SlashValue; // Forward declaration of SlashValue
 void slash_str_print(SlashValue *value);
 size_t *slash_str_len(SlashValue *value);
 
+int slash_str_cmp(const void *a, const void *b);
 
 #endif /* SLASH_STR_H */

--- a/include/interpreter/types/slash_tuple.h
+++ b/include/interpreter/types/slash_tuple.h
@@ -42,6 +42,6 @@ void slash_tuple_print(SlashValue *value);
 size_t *slash_tuple_len(SlashValue *value);
 SlashValue slash_tuple_item_get(Scope *scope, SlashValue *self, SlashValue *index);
 bool slash_tuple_item_in(SlashValue *self, SlashValue *item);
-
+int slash_tuple_cmp(const void *a, const void *b);
 
 #endif /* SLASH_TUPLE_H */

--- a/include/interpreter/types/slash_value.h
+++ b/include/interpreter/types/slash_value.h
@@ -68,6 +68,9 @@ bool is_truthy(SlashValue *value);
 
 bool slash_value_eq(SlashValue *a, SlashValue *b);
 
+int slash_value_cmp_lt(const void *a, const void *b);
+int slash_value_cmp_gt(const void *a, const void *b);
+
 // SlashToStrFunc
 // SlashToReprFunc
 typedef void (*SlashPrintFunc)(SlashValue *self);
@@ -91,8 +94,8 @@ extern SlashItemAssignFunc slash_item_assign[SLASH_TYPE_COUNT];
 
 extern SlashItemInFunc slash_item_in[SLASH_TYPE_COUNT];
 
-
 extern SlashValue slash_glob_none;
 
+extern int slash_cmp_precedence[SLASH_TYPE_COUNT];
 
 #endif /* SLASH_VALUE_H */

--- a/include/str_view.h
+++ b/include/str_view.h
@@ -36,6 +36,6 @@ void str_view_println(StrView s);
 double str_view_to_double(StrView s);
 int32_t str_view_to_int(StrView s);
 bool str_view_eq(StrView a, StrView b);
-
+int str_view_cmp(StrView a, StrView b);
 
 #endif /* STR_VIEW_H */

--- a/src/interpreter/types/slash_bool.c
+++ b/src/interpreter/types/slash_bool.c
@@ -22,3 +22,10 @@ void slash_bool_print(SlashValue *value)
 {
     printf("%s", value->boolean == true ? "true" : "false");
 }
+
+int slash_bool_cmp(const void *a, const void *b)
+{
+    SlashValue *A = (SlashValue *)a;
+    SlashValue *B = (SlashValue *)b;
+    return A->boolean - B->boolean;
+}

--- a/src/interpreter/types/slash_list.c
+++ b/src/interpreter/types/slash_list.c
@@ -207,7 +207,7 @@ SlashValue slash_list_sort(SlashValue *self, size_t argc, SlashValue *argv)
     if (match_signature("", argc, argv)) {
 	arraylist_sort(underlying, slash_value_cmp_lt);
     } else if (match_signature("b", argc, argv)) {
-    arraylist_sort(underlying, argv[0].boolean ? slash_value_cmp_lt : slash_value_cmp_gt);
+	arraylist_sort(underlying, argv[0].boolean ? slash_value_cmp_lt : slash_value_cmp_gt);
     } else {
 	report_runtime_error("Bad method args, expected no args or a single boolean.");
 	ASSERT_NOT_REACHED;

--- a/src/interpreter/types/slash_list.c
+++ b/src/interpreter/types/slash_list.c
@@ -84,7 +84,6 @@ bool slash_list_eq(SlashList *a, SlashList *b)
     return true;
 }
 
-
 /* common functions */
 
 void slash_list_print(SlashValue *value)
@@ -148,11 +147,11 @@ bool slash_list_item_in(SlashValue *self, SlashValue *item)
     return false;
 }
 
-
 /* methods */
 SlashMethod slash_list_methods[SLASH_LIST_METHODS_COUNT] = {
     { .name = "pop", .fp = slash_list_pop },
     { .name = "len", .fp = slash_list_len },
+    { .name = "sort", .fp = slash_list_sort },
 };
 
 SlashValue slash_list_pop(SlashValue *self, size_t argc, SlashValue *argv)
@@ -197,4 +196,22 @@ SlashValue slash_list_len(SlashValue *self, size_t argc, SlashValue *argv)
 
     SlashValue len = { .type = SLASH_NUM, .num = (double)underlying->size };
     return len;
+}
+
+SlashValue slash_list_sort(SlashValue *self, size_t argc, SlashValue *argv)
+{
+    assert(self->type == SLASH_LIST);
+
+    ArrayList *underlying = self->list.underlying;
+
+    if (match_signature("", argc, argv)) {
+	arraylist_sort(underlying, slash_value_cmp_lt);
+    } else if (match_signature("b", argc, argv)) {
+    arraylist_sort(underlying, argv[0].boolean ? slash_value_cmp_lt : slash_value_cmp_gt);
+    } else {
+	report_runtime_error("Bad method args, expected no args or a single boolean.");
+	ASSERT_NOT_REACHED;
+    }
+
+    return (SlashValue){ .type = SLASH_NONE };
 }

--- a/src/interpreter/types/slash_num.c
+++ b/src/interpreter/types/slash_num.c
@@ -33,12 +33,12 @@ int slash_num_cmp(const void *a, const void *b)
     double sum = A->num - B->num;
 
     if (sum < 1 && sum > -1) {
-        if (A->num > B->num)
-        return 1;
-        else if (A->num < B->num)
-        return -1;
-        else
-        return 0;
+	if (A->num > B->num)
+	    return 1;
+	else if (A->num < B->num)
+	    return -1;
+	else
+	    return 0;
     }
 
     return (int)(sum);

--- a/src/interpreter/types/slash_num.c
+++ b/src/interpreter/types/slash_num.c
@@ -24,3 +24,22 @@ void slash_num_print(SlashValue *value)
     else
 	printf("%f", value->num);
 }
+
+int slash_num_cmp(const void *a, const void *b)
+{
+    SlashValue *A = (SlashValue *)a;
+    SlashValue *B = (SlashValue *)b;
+
+    double sum = A->num - B->num;
+
+    if (sum < 1 && sum > -1) {
+        if (A->num > B->num)
+        return 1;
+        else if (A->num < B->num)
+        return -1;
+        else
+        return 0;
+    }
+
+    return (int)(sum);
+}

--- a/src/interpreter/types/slash_str.c
+++ b/src/interpreter/types/slash_str.c
@@ -29,3 +29,10 @@ size_t *slash_str_len(SlashValue *value)
 {
     return &value->str.size;
 }
+
+int slash_str_cmp(const void *a, const void *b)
+{
+    SlashValue *A = (SlashValue *)a;
+    SlashValue *B = (SlashValue *)b;
+    return str_view_cmp(A->str, B->str);
+}

--- a/src/interpreter/types/slash_tuple.c
+++ b/src/interpreter/types/slash_tuple.c
@@ -104,11 +104,11 @@ int slash_tuple_cmp(const void *a, const void *b)
     size_t min_size = A->tuple.size < B->tuple.size ? A->tuple.size : B->tuple.size;
 
     while (i < min_size && result == 0) {
-        if (A->type != B->type)
-            return -__INT_MAX__;
-        
-        result = slash_value_cmp_lt(&A->tuple.values[i], &B->tuple.values[i]);
-        i++;
+	if (A->type != B->type)
+	    return -__INT_MAX__;
+
+	result = slash_value_cmp_lt(&A->tuple.values[i], &B->tuple.values[i]);
+	i++;
     }
 
     return result;

--- a/src/interpreter/types/slash_tuple.c
+++ b/src/interpreter/types/slash_tuple.c
@@ -92,3 +92,24 @@ bool slash_tuple_item_in(SlashValue *self, SlashValue *item)
 
     return false;
 }
+
+int slash_tuple_cmp(const void *a, const void *b)
+{
+    SlashValue *A = (SlashValue *)a;
+    SlashValue *B = (SlashValue *)b;
+
+    int result = 0;
+
+    size_t i = 0;
+    size_t min_size = A->tuple.size < B->tuple.size ? A->tuple.size : B->tuple.size;
+
+    while (i < min_size && result == 0) {
+        if (A->type != B->type)
+            return -__INT_MAX__;
+        
+        result = slash_value_cmp_lt(&A->tuple.values[i], &B->tuple.values[i]);
+        i++;
+    }
+
+    return result;
+}

--- a/src/interpreter/types/slash_value.c
+++ b/src/interpreter/types/slash_value.c
@@ -199,3 +199,70 @@ bool slash_value_eq(SlashValue *a, SlashValue *b)
 
     return false;
 }
+
+int slash_cmp_precedence[SLASH_TYPE_COUNT] = {
+    /* bool */
+    0,
+    /* str */
+    2,
+    /* num */
+    1,
+    /* shident */
+    __INT_MAX__,
+    /* range */
+    __INT_MAX__,
+    /* list */
+    __INT_MAX__,
+    /* tuple */
+    3,
+    /* map */
+    __INT_MAX__,
+    /* none */
+    __INT_MAX__,
+};
+
+int slash_value_cmp_lt(const void *a, const void *b)
+{
+    SlashValue *A = (SlashValue *)a;
+    SlashValue *B = (SlashValue *)b;
+    
+    if (A->type != B->type) {
+        return slash_cmp_precedence[A->type] - slash_cmp_precedence[B->type];
+    }
+
+    switch (A->type) {
+        case SLASH_STR:
+            return slash_str_cmp(a, b);
+        case SLASH_BOOL:
+            return slash_bool_cmp(a, b);
+        case SLASH_NUM:
+            return slash_num_cmp(a, b);
+        case SLASH_TUPLE:
+            return slash_tuple_cmp(a, b);
+        default:
+            return __INT_MAX__;
+    }
+}
+
+int slash_value_cmp_gt(const void *a, const void *b)
+{
+    SlashValue *A = (SlashValue *)a;
+    SlashValue *B = (SlashValue *)b;
+
+    if (A->type != B->type) {
+        return slash_cmp_precedence[B->type] - slash_cmp_precedence[A->type];
+    }
+
+    switch (A->type) {
+        case SLASH_STR:
+            return slash_str_cmp(b, a);
+        case SLASH_BOOL:
+            return slash_bool_cmp(b, a);
+        case SLASH_NUM:
+            return slash_num_cmp(b, a);
+        case SLASH_TUPLE:
+            return slash_tuple_cmp(b, a);
+        default:
+            return __INT_MAX__;
+    }
+}

--- a/src/interpreter/types/slash_value.c
+++ b/src/interpreter/types/slash_value.c
@@ -225,22 +225,22 @@ int slash_value_cmp_lt(const void *a, const void *b)
 {
     SlashValue *A = (SlashValue *)a;
     SlashValue *B = (SlashValue *)b;
-    
+
     if (A->type != B->type) {
-        return slash_cmp_precedence[A->type] - slash_cmp_precedence[B->type];
+	return slash_cmp_precedence[A->type] - slash_cmp_precedence[B->type];
     }
 
     switch (A->type) {
-        case SLASH_STR:
-            return slash_str_cmp(a, b);
-        case SLASH_BOOL:
-            return slash_bool_cmp(a, b);
-        case SLASH_NUM:
-            return slash_num_cmp(a, b);
-        case SLASH_TUPLE:
-            return slash_tuple_cmp(a, b);
-        default:
-            return __INT_MAX__;
+    case SLASH_STR:
+	return slash_str_cmp(a, b);
+    case SLASH_BOOL:
+	return slash_bool_cmp(a, b);
+    case SLASH_NUM:
+	return slash_num_cmp(a, b);
+    case SLASH_TUPLE:
+	return slash_tuple_cmp(a, b);
+    default:
+	return __INT_MAX__;
     }
 }
 
@@ -250,19 +250,19 @@ int slash_value_cmp_gt(const void *a, const void *b)
     SlashValue *B = (SlashValue *)b;
 
     if (A->type != B->type) {
-        return slash_cmp_precedence[B->type] - slash_cmp_precedence[A->type];
+	return slash_cmp_precedence[B->type] - slash_cmp_precedence[A->type];
     }
 
     switch (A->type) {
-        case SLASH_STR:
-            return slash_str_cmp(b, a);
-        case SLASH_BOOL:
-            return slash_bool_cmp(b, a);
-        case SLASH_NUM:
-            return slash_num_cmp(b, a);
-        case SLASH_TUPLE:
-            return slash_tuple_cmp(b, a);
-        default:
-            return __INT_MAX__;
+    case SLASH_STR:
+	return slash_str_cmp(b, a);
+    case SLASH_BOOL:
+	return slash_bool_cmp(b, a);
+    case SLASH_NUM:
+	return slash_num_cmp(b, a);
+    case SLASH_TUPLE:
+	return slash_tuple_cmp(b, a);
+    default:
+	return __INT_MAX__;
     }
 }

--- a/src/str_view.c
+++ b/src/str_view.c
@@ -176,3 +176,8 @@ bool str_view_eq(StrView a, StrView b)
 
     return true;
 }
+
+int str_view_cmp(StrView a, StrView b)
+{
+    return memcmp(a.view, b.view, a.size < b.size ? a.size : b.size);
+}

--- a/test/internal_tests/list.slash
+++ b/test/internal_tests/list.slash
@@ -58,5 +58,60 @@ var underlying = [1, 2, 3, 4, 5]
     assert $two in $list1
 }
 
+# sorting with numbers asc
+{
+    var list1 = [3, 4, 1, 5, 2, 8, 4]
+    $list1.sort()
+    var idx = 0
+    var nx = 1
+    loop $nx < $list1.len() {
+        assert $list1[$idx] <= $list1[$nx]
+        $nx = $nx + 1
+        $idx = $idx + 1
+    }
+}
+
+# sorting with numbers desc
+{
+    var list1 = [3, 4, 1, 5, 2, 8, 4]
+    $list1.sort(false)
+    var idx = 0
+    var nx = 1
+    loop $nx < $list1.len() {
+        assert $list1[$idx] >= $list1[$nx]
+        $nx = $nx + 1
+        $idx = $idx + 1
+    }
+}
+
+
+
+# sorting with strings and numbers
+{
+    var list1 = ["Nicolai", "Callum", 2, "Aidan", 4, "Zach", "Brendan", 1]
+    $list1.sort()
+    var idx = 0
+    var nx = 1
+    loop $nx < $list1.len() {
+        var current = $list1[$idx]
+        echo $current
+        $nx = $nx + 1
+        $idx = $idx + 1
+    }
+}
+
+# sorting with tuples
+{
+    var list1 = [' 21, 3 ', ' 5, 4 ', ' 4, 6 ', ' 7, "Cock" ', ' "Balls", 10 ', ' 1, 2, '3, 4' ', ' 1, 1 ']
+
+    $list1.sort(false)
+
+    loop item in $list1 {
+        var fst = $item[0]
+        var snd = $item[1]
+        echo "(" $fst "," $snd ")"
+    }
+}
+
 # inline subscript 
 assert [1, 2, 3][0] == 1


### PR DESCRIPTION
I have implemented sorting to list structures. This allows for sorting ascending and descending. I have added some tests that show this, although since comparisons only exist for numbers at the moment, I have just decided to print.

Features added:
- Numbers will be sorted against each other.
- Booleans will be sorted against each other.
- Strings will be sorted against each other.
- Lists containing different datatypes will be sorted by type precedence, and then each type compared against itself. Booleans have least precedence, then numbers, then strings, then tuples.
- Tuples will be sorted by index. If the first elements are equal, then the second is checked etc.