### PR TITLE
fix: SlashFunction in REPL 

### DIFF
--- a/include/interpreter/ast.h
+++ b/include/interpreter/ast.h
@@ -77,7 +77,7 @@ typedef struct {
 
 typedef struct {
     ExprType type;
-    ArenaLL seq;
+    ArenaLL seq; // pointers to Exprs
 } SequenceExpr;
 
 /* expressions */
@@ -214,7 +214,7 @@ typedef struct {
 typedef struct {
     StmtType type;
     StrView cmd_name;
-    ArenaLL *arg_exprs;
+    ArenaLL *arg_exprs; // list of exprs
 } CmdStmt;
 
 typedef struct {
@@ -239,7 +239,7 @@ typedef struct {
     StmtType type;
     Stmt *left;
     TokenType operator_;
-    union {
+    union { // if operator_ is t_greater then union is expr
 	Stmt *right_stmt;
 	Expr *right_expr;
     };
@@ -256,6 +256,7 @@ typedef struct {
 Expr *expr_alloc(Arena *ast_arena, ExprType type);
 Stmt *stmt_alloc(Arena *ast_arena, StmtType type);
 Stmt *stmt_copy(Arena *arena, Stmt *to_copy);
+Expr *expr_copy(Arena *arena, Expr *to_copy);
 
 void ast_print(ArrayList *ast_heads);
 

--- a/include/interpreter/ast.h
+++ b/include/interpreter/ast.h
@@ -255,6 +255,7 @@ typedef struct {
 /* functions */
 Expr *expr_alloc(Arena *ast_arena, ExprType type);
 Stmt *stmt_alloc(Arena *ast_arena, StmtType type);
+Stmt *stmt_copy(Arena *arena, Stmt *to_copy);
 
 void ast_print(ArrayList *ast_heads);
 

--- a/include/lib/str_view.h
+++ b/include/lib/str_view.h
@@ -21,6 +21,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include "sac/sac.h"
+
 
 /*
  * the main string implementation used throughout the interpreter
@@ -38,5 +40,7 @@ int32_t str_view_to_int(StrView s);
 bool str_view_eq(StrView a, StrView b);
 int str_view_cmp(StrView a, StrView b);
 void str_view_to_cstr(StrView view, char *cstr);
+
+StrView str_view_arena_copy(Arena *arena, StrView to_copy);
 
 #endif /* STR_VIEW_H */

--- a/src/interpreter/ast.c
+++ b/src/interpreter/ast.c
@@ -86,6 +86,47 @@ Stmt *stmt_alloc(Arena *ast_arena, StmtType type)
     return stmt;
 }
 
+Stmt *stmt_copy(Arena *arena, Stmt *to_copy)
+{
+    /* Need expr_copy as well :-( */
+    Stmt *copy = stmt_alloc(arena, to_copy->type);
+    switch (to_copy->type) {
+        case STMT_VAR: {
+            break;
+        }
+        case STMT_SEQ_VAR:
+            break;
+        case STMT_EXPRESSION: {
+            ((ExpressionStmt *)copy)->expression = ((ExpressionStmt *)to_copy)->expression;
+            break;
+        }
+        case STMT_CMD:
+            break;
+        case STMT_LOOP:
+            break;
+        case STMT_ITER_LOOP:
+            break;
+        case STMT_IF:
+            break;
+        case STMT_BLOCK:
+            break;
+        case STMT_ASSIGN:
+            break;
+        case STMT_PIPELINE:
+            break;
+        case STMT_ASSERT:
+            break;
+        case STMT_BINARY:
+            break;
+        case STMT_ABRUPT_CONTROL_FLOW:
+            break;
+        case STMT_ENUM_COUNT:
+            break;
+    }
+
+    return copy;
+}
+
 
 /* arena */
 void ast_arena_init(Arena *ast_arena)

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -342,7 +342,7 @@ static SlashValue eval_list(Interpreter *interpreter, ListExpr *expr)
 
 static SlashValue eval_function(Interpreter *interpreter, FunctionExpr *expr)
 {
-    /* 
+    /*
      * SlashFunction is "special" in that it holds pointers to the AST and source (through StrViews)
      * When using the REPL, the AST will and source will be reset on each new command, meaning we
      * have to make copies of the params and function body.
@@ -350,15 +350,12 @@ static SlashValue eval_function(Interpreter *interpreter, FunctionExpr *expr)
     ArenaLL params;
     arena_ll_init(interpreter->scope->arena_tmp.arena, &params);
     LLItem *item;
-    ARENA_LL_FOR_EACH(&expr->params, item) {
-        StrView *param = item->value;
-        StrView *param_cpy = scope_alloc(interpreter->scope, sizeof(StrView));
-        char *view_cpy = scope_alloc(interpreter->scope, param->size + 1);
-        strncpy(view_cpy, param->view, param->size);
-        view_cpy[param->size] = 0;
-        param_cpy->view = view_cpy;
-        param_cpy->size = params.size;
-        arena_ll_append(&params, param);
+    ARENA_LL_FOR_EACH(&expr->params, item)
+    {
+	StrView *param = item->value;
+	StrView *param_cpy = scope_alloc(interpreter->scope, sizeof(StrView));
+	*param_cpy = str_view_arena_copy(interpreter->scope->arena_tmp.arena, *param);
+	arena_ll_append(&params, param);
     }
 
     Stmt *body_cpy = stmt_copy(interpreter->scope->arena_tmp.arena, (Stmt *)expr->body);

--- a/src/interpreter/interpreter.c
+++ b/src/interpreter/interpreter.c
@@ -342,9 +342,27 @@ static SlashValue eval_list(Interpreter *interpreter, ListExpr *expr)
 
 static SlashValue eval_function(Interpreter *interpreter, FunctionExpr *expr)
 {
-    (void)interpreter;
-    // TODO: closure
-    SlashFunction function = { .params = expr->params, .body = expr->body };
+    /* 
+     * SlashFunction is "special" in that it holds pointers to the AST and source (through StrViews)
+     * When using the REPL, the AST will and source will be reset on each new command, meaning we
+     * have to make copies of the params and function body.
+     */
+    ArenaLL params;
+    arena_ll_init(interpreter->scope->arena_tmp.arena, &params);
+    LLItem *item;
+    ARENA_LL_FOR_EACH(&expr->params, item) {
+        StrView *param = item->value;
+        StrView *param_cpy = scope_alloc(interpreter->scope, sizeof(StrView));
+        char *view_cpy = scope_alloc(interpreter->scope, param->size + 1);
+        strncpy(view_cpy, param->view, param->size);
+        view_cpy[param->size] = 0;
+        param_cpy->view = view_cpy;
+        param_cpy->size = params.size;
+        arena_ll_append(&params, param);
+    }
+
+    Stmt *body_cpy = stmt_copy(interpreter->scope->arena_tmp.arena, (Stmt *)expr->body);
+    SlashFunction function = { .params = params, .body = (BlockStmt *)body_cpy };
     return (SlashValue){ .T = &function_type_info, .function = function };
 }
 

--- a/src/lib/str_view.c
+++ b/src/lib/str_view.c
@@ -185,3 +185,11 @@ void str_view_to_cstr(StrView view, char *cstr)
     memcpy(cstr, view.view, view.size);
     cstr[view.size] = 0;
 }
+
+StrView str_view_arena_copy(Arena *arena, StrView to_copy)
+{
+    // TODO: since we are now copying we also have the opportunity to null terminate
+    char *view_cpy = m_arena_alloc(arena, sizeof(char) * to_copy.size);
+    memcpy(view_cpy, to_copy.view, to_copy.size);
+    return (StrView){ .view = view_cpy, .size = to_copy.size };
+}


### PR DESCRIPTION
Issue is that AST nodes and StrViews are reset after each command in the REPL. This causes functions to point to "freed" data. The solution is to deep copy each AST node included in the function.